### PR TITLE
fix: prevent infinite fork loop in pip package CLI wrapper

### DIFF
--- a/pip-package/rpytest_cli/__init__.py
+++ b/pip-package/rpytest_cli/__init__.py
@@ -40,17 +40,28 @@ def get_binary_path() -> Path:
         if binary_path.exists():
             return binary_path
 
-    # Try system PATH
-    try:
-        result = subprocess.run(
-            ["which", "rpytest"],
-            capture_output=True,
-            text=True,
-            check=True
-        )
-        return Path(result.stdout.strip())
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        pass
+    # Try system PATH, skipping any Python wrapper scripts to avoid
+    # infinite fork loops when the pip package entry point shadows
+    # the Rust binary.
+    this_script = Path(sys.argv[0]).resolve() if sys.argv[0] else None
+    path_dirs = os.get_exec_path()
+    for directory in path_dirs:
+        candidate = Path(directory) / "rpytest"
+        if not candidate.is_file() or not os.access(candidate, os.X_OK):
+            continue
+        resolved = candidate.resolve()
+        # Skip if it resolves to the same file as the current wrapper
+        if this_script and resolved == this_script:
+            continue
+        # Skip Python scripts (they have a #! shebang pointing to python)
+        try:
+            with open(resolved, "rb") as f:
+                header = f.read(64)
+            if header.startswith(b"#!") and b"python" in header.split(b"\n")[0]:
+                continue
+        except OSError:
+            continue
+        return resolved
 
     # Try cargo target directory (development)
     workspace_root = pkg_dir.parent.parent


### PR DESCRIPTION
## Summary
- Fixes #2
- The `get_binary_path()` function in `pip-package/rpytest_cli/__init__.py` used `which rpytest` which found the venv wrapper script itself, causing infinite subprocess fork recursion
- Replaced with manual PATH iteration that skips the wrapper script and Python shebang executables

## Test plan
- [ ] Install pip package in a venv: `pip install -e pip-package/`
- [ ] Run `rpytest --version` — should return version without spawning zombie processes
- [ ] Verify `ps aux | grep rpytest` shows only one process