### PR TITLE
fix: update install docs to include rpytest-daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,18 @@ The speed comes from a persistent daemon that keeps Python warm between runs. No
 # Via pip (recommended)
 pip install rpytest
 
-# Via cargo
-cargo install rpytest
+# Via cargo (installs both the CLI and the daemon)
+cargo install rpytest rpytest-daemon
 
 # From source
 git clone https://github.com/neul-labs/rpytest.git
-cd rpytest && cargo install --path crates/rpytest
+cd rpytest
+cargo install --path crates/rpytest
+cargo install --path crates/rpytest-daemon
 ```
+
+> **Note:** rpytest requires the `rpytest-daemon` binary to function. Both packages
+> must be installed when using `cargo install`.
 
 ## Usage
 

--- a/crates/rpytest-daemon/Cargo.toml
+++ b/crates/rpytest-daemon/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "rpytest-daemon"
-version = "0.1.1"
-edition = "2021"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/neul-labs/rpytest"
-documentation = "https://docs.neullabs.com/rpytest"
-homepage = "https://github.com/neul-labs/rpytest"
-authors = ["neul-labs"]
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+authors.workspace = true
 readme = "../../README.md"
 keywords = ["pytest", "testing", "python", "daemon"]
 categories = ["development-tools::testing"]

--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -11,15 +11,19 @@
 The recommended way to install rpytest:
 
 ```bash
-cargo install rpytest
+cargo install rpytest rpytest-daemon
 ```
+
+!!! important
+    Both the `rpytest` CLI and the `rpytest-daemon` binary must be installed.
+    Without the daemon, rpytest cannot execute tests.
 
 ## Install from Source
 
 Clone and build:
 
 ```bash
-git clone https://github.com/user/rpytest.git
+git clone https://github.com/neul-labs/rpytest.git
 cd rpytest
 cargo build --release
 
@@ -29,17 +33,17 @@ export PATH="$PWD/target/release:$PATH"
 
 ## Python Dependencies
 
-rpytest requires the Python daemon package to be installed in your project's virtual environment:
+rpytest requires the Python package to be installed in your project's virtual environment:
 
 ```bash
 # Using pip
-pip install rpytest-daemon
+pip install rpytest
 
 # Using uv
-uv pip install rpytest-daemon
+uv pip install rpytest
 
 # Or install from source
-cd daemon/
+cd pip-package/
 pip install -e .
 ```
 
@@ -68,7 +72,7 @@ rpytest automatically detects your Python environment in this order:
 
     ```bash
     uv venv
-    uv pip install rpytest-daemon pytest
+    uv pip install rpytest pytest
     rpytest tests/
     ```
 

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -26,8 +26,8 @@ rpytest is a high-performance test runner that provides full pytest compatibilit
 ## Quick Example
 
 ```bash
-# Install rpytest
-cargo install rpytest
+# Install rpytest (both CLI and daemon are required)
+cargo install rpytest rpytest-daemon
 
 # Run tests (same as pytest!)
 rpytest tests/


### PR DESCRIPTION
## Summary
- Fixes #6
- `cargo install rpytest` only installs the CLI binary, not the required daemon
- Updated README.md, installation docs, and quick start to show `cargo install rpytest rpytest-daemon`
- Added important admonition explaining both packages are required
- Migrated `crates/rpytest-daemon/Cargo.toml` metadata to workspace-inherited fields for consistency

## Test plan
- [ ] Review updated README.md installation section
- [ ] Review updated `documentation/docs/getting-started/installation.md`
- [ ] Verify `rpytest-daemon` Cargo.toml has proper metadata for crates.io publication