### PR TITLE
fix: correct package name and placeholder URLs in docs

### DIFF
--- a/documentation/docs/features/sharding.md
+++ b/documentation/docs/features/sharding.md
@@ -90,7 +90,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install dependencies
-        run: pip install -e . rpytest-daemon
+        run: pip install -e . rpytest
 
       - name: Run tests
         run: |

--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -19,7 +19,7 @@ cargo install rpytest
 Clone and build:
 
 ```bash
-git clone https://github.com/user/rpytest.git
+git clone https://github.com/neul-labs/rpytest.git
 cd rpytest
 cargo build --release
 
@@ -29,17 +29,17 @@ export PATH="$PWD/target/release:$PATH"
 
 ## Python Dependencies
 
-rpytest requires the Python daemon package to be installed in your project's virtual environment:
+rpytest requires the Python package to be installed in your project's virtual environment:
 
 ```bash
 # Using pip
-pip install rpytest-daemon
+pip install rpytest
 
 # Using uv
-uv pip install rpytest-daemon
+uv pip install rpytest
 
 # Or install from source
-cd daemon/
+cd pip-package/
 pip install -e .
 ```
 
@@ -68,7 +68,7 @@ rpytest automatically detects your Python environment in this order:
 
     ```bash
     uv venv
-    uv pip install rpytest-daemon pytest
+    uv pip install rpytest pytest
     rpytest tests/
     ```
 

--- a/documentation/docs/getting-started/migration.md
+++ b/documentation/docs/getting-started/migration.md
@@ -7,8 +7,8 @@ rpytest is designed as a drop-in replacement for pytest. Most projects can switc
 ### Step 1: Install rpytest
 
 ```bash
-cargo install rpytest
-pip install rpytest-daemon
+cargo install rpytest rpytest-daemon
+pip install rpytest
 ```
 
 ### Step 2: Replace pytest with rpytest
@@ -217,7 +217,7 @@ rpytest tests/ -- --plugin-flag=value
 Ensure the daemon package is installed in the same environment:
 
 ```bash
-pip install rpytest-daemon
+pip install rpytest
 ```
 
 ### Collection Differences

--- a/documentation/docs/guide/configuration.md
+++ b/documentation/docs/guide/configuration.md
@@ -268,7 +268,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -e .
-          pip install rpytest-daemon
+          pip install rpytest
 
       - name: Run tests
         run: rpytest tests/ -v --junitxml=report.xml

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: rpytest
 site_description: Rust-powered, drop-in replacement for pytest
 site_url: https://rpytest.dev
-repo_url: https://github.com/user/rpytest
+repo_url: https://github.com/neul-labs/rpytest
 repo_name: rpytest
 
 theme:
@@ -85,4 +85,4 @@ nav:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/user/rpytest
+      link: https://github.com/neul-labs/rpytest

--- a/pip-package/README.md
+++ b/pip-package/README.md
@@ -12,7 +12,7 @@ Or install from source:
 
 ```bash
 # Clone the repository
-git clone https://github.com/user/rpytest.git
+git clone https://github.com/neul-labs/rpytest.git
 cd rpytest
 
 # Build the Rust binary

--- a/pip-package/pyproject.toml
+++ b/pip-package/pyproject.toml
@@ -42,9 +42,9 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/user/rpytest"
-Repository = "https://github.com/user/rpytest"
-Issues = "https://github.com/user/rpytest/issues"
+Homepage = "https://github.com/neul-labs/rpytest"
+Repository = "https://github.com/neul-labs/rpytest"
+Issues = "https://github.com/neul-labs/rpytest/issues"
 
 [project.scripts]
 rpytest = "rpytest_cli:main"

--- a/pip-package/rpytest_cli/download.py
+++ b/pip-package/rpytest_cli/download.py
@@ -10,7 +10,7 @@ import urllib.request
 from pathlib import Path
 
 # GitHub release URL pattern
-RELEASE_URL = "https://github.com/user/rpytest/releases/download"
+RELEASE_URL = "https://github.com/neul-labs/rpytest/releases/download"
 VERSION = "0.1.0"
 
 


### PR DESCRIPTION
## Summary
- Fixes #1
- Replaced all references to non-existent `rpytest-daemon` pip package with `rpytest` (the actual package name)
- Fixed placeholder URLs `github.com/user/rpytest` → `github.com/neul-labs/rpytest` in pyproject.toml, README, download script, and mkdocs config
- Fixed source install path from `cd daemon/` to `cd pip-package/`

## Test plan
- [ ] Review all doc files for correct package name references
- [ ] Verify `pip-package/pyproject.toml` URLs point to neul-labs/rpytest
- [ ] Verify `documentation/mkdocs.yml` repo_url is correct
- [ ] Search for any remaining `github.com/user/` references