### PR TITLE
fix: correct package name, install docs, and workspace metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,18 @@ brew install rpytest
 # Via npm
 npm install -g rpytest
 
-# Via cargo
-cargo install rpytest
+# Via cargo (installs both the CLI and the daemon)
+cargo install rpytest rpytest-daemon
 
 # From source
 git clone https://github.com/neul-labs/rpytest.git
-cd rpytest && cargo install --path crates/rpytest
+cd rpytest
+cargo install --path crates/rpytest
+cargo install --path crates/rpytest-daemon
 ```
+
+> **Note:** rpytest requires the `rpytest-daemon` binary to function. Both packages
+> must be installed when using `cargo install`.
 
 ## Usage
 

--- a/crates/rpytest-daemon/Cargo.toml
+++ b/crates/rpytest-daemon/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "rpytest-daemon"
-version = "0.1.2"
-edition = "2021"
-license = "MIT"
-repository = "https://github.com/neul-labs/rpytest"
-documentation = "https://docs.neullabs.com/rpytest"
-homepage = "https://github.com/neul-labs/rpytest"
-authors = ["neul-labs"]
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+authors.workspace = true
 readme = "../../README.md"
 keywords = ["pytest", "testing", "python", "daemon"]
 categories = ["development-tools::testing"]

--- a/documentation/docs/features/sharding.md
+++ b/documentation/docs/features/sharding.md
@@ -90,7 +90,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install dependencies
-        run: pip install -e . rpytest-daemon
+        run: pip install -e . rpytest
 
       - name: Run tests
         run: |

--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -11,7 +11,7 @@
 The recommended way to install rpytest:
 
 ```bash
-cargo install rpytest
+cargo install rpytest rpytest-daemon
 ```
 
 ## Install from Source
@@ -29,14 +29,14 @@ export PATH="$PWD/target/release:$PATH"
 
 ## Python Dependencies
 
-rpytest requires the Python daemon package to be installed in your project's virtual environment:
+rpytest requires the Python package to be installed in your project's virtual environment:
 
 ```bash
 # Using pip
-pip install rpytest-daemon
+pip install rpytest
 
 # Using uv
-uv pip install rpytest-daemon
+uv pip install rpytest
 
 # Or install from source
 cd packages/pypi/
@@ -68,7 +68,7 @@ rpytest automatically detects your Python environment in this order:
 
     ```bash
     uv venv
-    uv pip install rpytest-daemon pytest
+    uv pip install rpytest pytest
     rpytest tests/
     ```
 

--- a/documentation/docs/getting-started/migration.md
+++ b/documentation/docs/getting-started/migration.md
@@ -7,8 +7,8 @@ rpytest is designed as a drop-in replacement for pytest. Most projects can switc
 ### Step 1: Install rpytest
 
 ```bash
-cargo install rpytest
-pip install rpytest-daemon
+cargo install rpytest rpytest-daemon
+pip install rpytest
 ```
 
 ### Step 2: Replace pytest with rpytest
@@ -217,7 +217,7 @@ rpytest tests/ -- --plugin-flag=value
 Ensure the daemon package is installed in the same environment:
 
 ```bash
-pip install rpytest-daemon
+pip install rpytest
 ```
 
 ### Collection Differences

--- a/documentation/docs/guide/configuration.md
+++ b/documentation/docs/guide/configuration.md
@@ -268,7 +268,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -e .
-          pip install rpytest-daemon
+          pip install rpytest
 
       - name: Run tests
         run: rpytest tests/ -v --junitxml=report.xml

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -26,8 +26,8 @@ rpytest is a high-performance test runner that provides full pytest compatibilit
 ## Quick Example
 
 ```bash
-# Install rpytest
-cargo install rpytest
+# Install rpytest (both CLI and daemon are required)
+cargo install rpytest rpytest-daemon
 
 # Run tests (same as pytest!)
 rpytest tests/


### PR DESCRIPTION
## Summary
- Fixes #1
- Fixes #6
- Replaced all references to non-existent `rpytest-daemon` pip package with `rpytest` (the actual package name)
- Updated cargo install docs to show `cargo install rpytest rpytest-daemon` and explain both are required
- Migrated `crates/rpytest-daemon/Cargo.toml` metadata to workspace-inherited fields

## Test plan
- [ ] Review all doc files for correct package name references
- [ ] Verify `cargo install` docs mention both packages
- [ ] Verify `rpytest-daemon` Cargo.toml uses workspace inheritance