### PR TITLE
fix: prevent infinite fork loop in pip package CLI wrapper

### DIFF
--- a/packages/pypi/rpytest_cli/__init__.py
+++ b/packages/pypi/rpytest_cli/__init__.py
@@ -40,17 +40,28 @@ def get_binary_path() -> Path:
         if binary_path.exists():
             return binary_path
 
-    # Try system PATH
-    try:
-        result = subprocess.run(
-            ["which", "rpytest"],
-            capture_output=True,
-            text=True,
-            check=True
-        )
-        return Path(result.stdout.strip())
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        pass
+    # Try system PATH, skipping any Python wrapper scripts to avoid
+    # infinite fork loops when the pip package entry point shadows
+    # the Rust binary.
+    this_script = Path(sys.argv[0]).resolve() if sys.argv[0] else None
+    path_dirs = os.get_exec_path()
+    for directory in path_dirs:
+        candidate = Path(directory) / "rpytest"
+        if not candidate.is_file() or not os.access(candidate, os.X_OK):
+            continue
+        resolved = candidate.resolve()
+        # Skip if it resolves to the same file as the current wrapper
+        if this_script and resolved == this_script:
+            continue
+        # Skip Python scripts (they have a #! shebang pointing to python)
+        try:
+            with open(resolved, "rb") as f:
+                header = f.read(64)
+            if header.startswith(b"#!") and b"python" in header.split(b"\n")[0]:
+                continue
+        except OSError:
+            continue
+        return resolved
 
     # Try cargo target directory (development)
     workspace_root = pkg_dir.parent.parent


### PR DESCRIPTION
## Summary
- Fixes #2
- Replaced `which rpytest` with manual PATH iteration that skips the wrapper script itself and Python shebang executables
- This prevents the pip package entry point from finding itself and spawning an infinite subprocess recursion

## Test plan
- [ ] Install pip package in a venv: `pip install -e packages/pypi/`
- [ ] Run `rpytest --version` — should return version without spawning zombie processes
- [ ] Verify `ps aux | grep rpytest` shows only one process